### PR TITLE
fix(icon-cloud): use primary text color when icons are not an accessible contrast

### DIFF
--- a/src/modules/Skills/components/IconCloud/index.tsx
+++ b/src/modules/Skills/components/IconCloud/index.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState, useMemo, memo } from 'react'
 import { fetchSimpleIcons, Cloud, renderSimpleIcon } from 'react-icon-cloud'
 import { useThemeContext } from '@/context/ThemeContext'
 import { Mode } from '@/types/theme'
+import { useTheme } from 'styled-components'
 
 type IconData = Awaited<ReturnType<typeof fetchSimpleIcons>>
 
 export const IconCloud = memo(function IconCloud(props: any) {
   const { mode } = useThemeContext()
+  const theme = useTheme()
 
   const cloudProps: any = {
     containerProps: {
@@ -34,8 +36,8 @@ export const IconCloud = memo(function IconCloud(props: any) {
     return renderSimpleIcon({
       icon,
       minContrastRatio: mode === Mode.Light ? 1 : 1.2,
-      bgHex: '#fff',
-      fallbackHex: '#0e0e0e',
+      bgHex: theme.colors.primary,
+      fallbackHex: theme.colors.textPrimary,
       size: 42,
       aProps: {
         href: undefined,


### PR DESCRIPTION
Hey Valentine,

Your portfolio site looks amazing! Great work on this 😃. I noticed that the theme was not plugged into the icon cloud to allow it to fallback to a color when it's contrast it not accessible. I hope this change helps.

## before
![before](https://user-images.githubusercontent.com/71202372/207434595-77c4c08c-d41f-4503-a14b-2496b1f473f6.gif)

## after
![after](https://user-images.githubusercontent.com/71202372/207434637-9830f1b9-d758-4af7-8a36-d4f74b535f29.gif)
  